### PR TITLE
feat(ios): update stripe objects for latest sdk

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,11 @@ Plugin for Cordova to use the [native android SDK](https://github.com/stripe/str
 
 ## Installing the plugin ##
 ```
-cordova plugin add cordova-plugin-filepickerio --save
+cordova plugin add cordova-plugin-stripe-payments --save
 ```
+
+### NOTE:
+This plugin now requires Cordova 9 as of version 0.1.1. If you are using Cordova 8 or lower, please use the 0.0.8 version of this plugin.
 
 ## Using the plugin ##
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cordova-plugin-stripe-payments",
   "description": "Stripe Card Entry plugin for Cordova. Available for Android and iOS.",
-  "version": "0.0.8",
+  "version": "0.1.1",
   "homepage": "https://github.com/rolamix/cordova-plugin-stripe-payments#readme",
   "author": "Rolamix <contact@rolamix.com> (https://rolamix.com)",
   "license": "MIT",

--- a/plugin.xml
+++ b/plugin.xml
@@ -3,7 +3,7 @@
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
     xmlns:android="http://schemas.android.com/apk/res/android"
     id="cordova-plugin-stripe-payments"
-    version="0.0.8">
+    version="0.1.1">
 
     <name>Stripe Payments</name>
     <description>Cordova plugin for Stripe payments using the native Android/iOS SDKs. Supports Apple Pay and card payments.</description>
@@ -14,15 +14,15 @@
     <issue>https://github.com/rolamix/cordova-plugin-stripe-payments/issues</issue>
 
     <engines>
-      <engine name="cordova" version=">=7.1.0"/>
-      <engine name="cordova-android" version=">=7.1.0"/>
+      <engine name="cordova" version=">=9.0.0"/>
+      <engine name="cordova-android" version=">=8.0.0"/>
       <!-- If installing on Cordova IOS 5.0, make sure to add
       <preference name="SwiftVersion" value="4.1" />
       to your config.xml under the ios platform section.
       If installing on Cordova iOS < 5.0, you need to add cordova-plugin-add-swift-support
       to your project and specify <preference name="UseSwiftLanguageVersion" value="4" />
       in your config.xml file under the ios platform section. -->
-      <engine name="cordova-ios" version=">=4.5.0"/>
+      <engine name="cordova-ios" version=">=5.0.0"/>
     </engines>
 
     <js-module src="www/StripePaymentsPlugin.js" name="StripePaymentsPlugin">
@@ -71,20 +71,22 @@
         </feature>
       </config-file>
 
+       <!--
       <framework src="Stripe" type="podspec" spec="~> 15.0.0" />
       <framework src="Alamofire" type="podspec" spec="~> 4.8.1" />
-      <framework src="CardIO" type="podspec" spec="~> 5.4.1" />
+      <framework src="CardIO" type="podspec" spec="~> 5.4.1" /> -->
+
       <!-- https://github.com/cordova-develop/cordova-plugin-pods3/blob/master/plugin.xml -->
-      <!-- <podspec>
+      <podspec>
         <config>
           <source url="https://github.com/CocoaPods/Specs.git"/>
         </config>
         <pods use-frameworks="true">
-          <pod name="Stripe" spec="~> 15.0.0" />
+          <pod name="Stripe" spec="~> 17.0.1" />
           <pod name="CardIO" spec="~> 5.4.1" />
           <pod name="Alamofire" spec="~> 4.8.1" swift-version="4.2" />
         </pods>
-      </podspec> -->
+      </podspec>
 
       <source-file src="src/ios/StripeAPIClient.swift" />
       <source-file src="src/ios/StripePaymentOptions.swift" />

--- a/src/ios/StripePaymentsPlugin.swift
+++ b/src/ios/StripePaymentsPlugin.swift
@@ -82,7 +82,7 @@ import Stripe
             paymentContext.hostViewController = self.viewController
         }
 
-        customerContext.clearCachedCustomer()
+        customerContext.clearCache()
     }
 
 
@@ -235,19 +235,20 @@ import Stripe
         print("[StripePaymentsPlugin].paymentContextDidChange: \(resultMsg)")
         successCallback(paymentStatusCallback, resultMsg, keepCallback: true)
     }
-
+    
     // This callback is triggered when requestPayment() completes successfully to create a Source.
     // This Source can then be used by the app to process a payment (create a charge, subscription etc.)
-    func paymentContext(_ paymentContext: STPPaymentContext, didCreatePaymentResult paymentResult: STPPaymentResult, completion: @escaping STPErrorBlock) {
+    func paymentContext(_ paymentContext: STPPaymentContext, didCreatePaymentResult paymentResult: STPPaymentResult, completion: @escaping STPPaymentStatusBlock) {
         // Create charge using payment result
         let resultMsg: [String : Any] = [
             "status": "PAYMENT_CREATED",
-            "source": paymentResult.source.stripeID
+            "source": paymentResult.paymentMethod.stripeId
+            // "source": paymentResult.source.stripeID
         ]
 
         print("[StripePaymentsPlugin].paymentContext.didCreatePaymentResult: \(resultMsg)")
         successCallback(paymentStatusCallback, resultMsg, keepCallback: true)
-        completion(nil)
+        completion(STPPaymentStatus.success, nil)
     }
 
     // This callback triggers due to:
@@ -313,4 +314,3 @@ import Stripe
     }
 
 }
-

--- a/src/ios/StripePaymentsPlugin.swift
+++ b/src/ios/StripePaymentsPlugin.swift
@@ -248,6 +248,9 @@ import Stripe
 
         print("[StripePaymentsPlugin].paymentContext.didCreatePaymentResult: \(resultMsg)")
         successCallback(paymentStatusCallback, resultMsg, keepCallback: true)
+
+        // This is here to, for example, inform the context that the user canceled payment (if we were processing it
+        // from the native side). However we are not handling it here.
         completion(STPPaymentStatus.success, nil)
     }
 


### PR DESCRIPTION
Updates usage of stripe iOS SDK to use latest objects after their refactoring

It's actually important to upgrade to this version of the SDK because they have finally brought the SDK into the present and are using a recent version of the Stripe API (may 2019) instead of one from 2015.

I haven't published this yet. I am testing it in our app.

TODO: Upgrade the Android library as well which as of this ticket, is now on version 11 (we are still on version 8). It appears to be a very involved process, not least of which it requires AndroidX which cordova does not support yet.